### PR TITLE
chore: update remix config when using javascript

### DIFF
--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -1,0 +1,19 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = ({ isTypeScript, rootDirectory }) => {
+  if (isTypeScript === false) {
+    let remixConfigPath = path.join(rootDirectory, "remix.config.js");
+    let remixConfig = require(remixConfigPath);
+    remixConfig.server = "./server.js";
+
+    let newConfig = `
+/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = ${JSON.stringify(remixConfig, null, 2)}
+`.trim();
+
+    fs.writeFileSync(remixConfigPath, newConfig);
+  }
+};

--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 
 module.exports = ({ isTypeScript, rootDirectory }) => {
-  if (isTypeScript === false) {
+  if (!isTypeScript) {
     let remixConfigPath = path.join(rootDirectory, "remix.config.js");
     let remixConfig = require(remixConfigPath);
     remixConfig.server = "./server.js";


### PR DESCRIPTION
## Description

Fixes a compilation error when JavaScript is selected in the Remix CLI for the Netlify Remix edge template.

Signed-off-by: Logan McAnsh <logan@mcan.sh>

Closes #14