### PR TITLE
chore: improve DX for the Edge template

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,23 @@ netlify init
 
 ## Development
 
-The Netlify CLI starts your app in development mode, rebuilding assets on file changes.
+The Remix dev server starts your app in development mode, rebuilding assets on file changes. To start the Remix dev server:
 
 ```sh
 npm run dev
 ```
 
 Open up [http://localhost:3000](http://localhost:3000), and you should be ready to go!
+
+The Netlify CLI builds a production version of your Remix App Server and splits it into Netlify Functions that run locally. This includes any custom Netlify functions you've developed. The Netlify CLI runs all of this in its development mode.
+
+```sh
+netlify dev
+```
+
+Open up [http://localhost:3000](http://localhost:3000), and you should be ready to go!
+
+Note: When running the Netlify CLI, file changes will rebuild assets, but you will not see the changes to the page you are on unless you do a browser refresh of the page. Due to how the Netlify CLI builds the Remix App Server, it does not support hot module reloading.
 
 ## Deployment
 
@@ -51,5 +61,5 @@ There are two ways to deploy your app to Netlify, you can either link your app t
 netlify deploy --build
 
 # production deployment
-netlify deploy --build --prod
+netlify deploy --build --prodnpx
 ```

--- a/README.md
+++ b/README.md
@@ -61,5 +61,5 @@ There are two ways to deploy your app to Netlify, you can either link your app t
 netlify deploy --build
 
 # production deployment
-netlify deploy --build --prodnpx
+netlify deploy --build --prod
 ```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build",
-    "dev": "cross-env NODE_ENV=development netlify dev",
+    "dev": "remix dev",
     "start": "cross-env NODE_ENV=production netlify dev"
   },
   "dependencies": {
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@remix-run/dev": "experimental-netlify-edge",
     "@remix-run/eslint-config": "experimental-netlify-edge",
+    "@remix-run/serve": "experimental-netlify-edge",
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.1",
     "eslint": "^8.11.0",

--- a/remix.config.js
+++ b/remix.config.js
@@ -3,6 +3,9 @@
  */
 module.exports = {
   serverBuildTarget: "netlify-edge",
-  server: "./server.js",
+  server:
+    process.env.NETLIFY || process.env.NETLIFY_LOCAL
+      ? './server.js'
+      : undefined,
   ignoredRouteFiles: [".*"],
 };


### PR DESCRIPTION
## Description

This changes the npm `dev` script to run `remix dev` so that a developer can build their app and get all the hot reloading goodness that the Remix dev server provides.

When they want to test the Edge function version, they can run `netlify dev`. The main difference is when running `ntl dev`, they are required to do a browser refresh of the page to see the changes they made.

For more context, see https://github.com/remix-run/remix/discussions/3753.

# Related Tickets & Documents

Closes: #43

Relates to:
- https://github.com/netlify-templates/kpop-stack/pull/56
- https://github.com/remix-run/remix/pull/3754


## Test Steps

First, ensure the [deploy review](https://deploy-preview-44--remix-edge-on.netlify.app/) renders.

1. Pull this PR locally, `gh co 56`
2. Run `npx create-remix@latest --template ./`
3. The Remix CLI will run using the Netlify Edge template.
4. Pick whatever options you want in the list of questions the CLI will ask. It doesn't matter if you pick TypeScript or JS. When choosing the project location, ensure you're not creating it at the root folder of the Netlify Edge template. (the folder the Remix CLI is currently running in)
5. Once the CLI is done running, change to your new project directory and run `npm install`.

## Test the Remix dev server

1. Run `npm run dev`
2. The Remix dev server starts and renders the main page when navigating to http://localhost:3000
6. Stop the Remix dev server.

## Test the Remix app server running in Netlify functions locally

1. Run `netlify dev`.  
2. The server running on Netlify functions locally starts and renders the main page when navigating to http://localhost:3000.

## Test a deploy via the CLI

1. Run `netlify deploy --build`. If your application isn't configured to deploy yet, ensure you've followed the steps in the README first to get your app configured to deploy to Netlify.
2. The application builds and deploys.
3. Navigate to the deploy preview.
7. The site loads.

## Test a deploy via git push or retrigger a deploy from the Netlify UI

1. Trigger a deploy from the Netlify UI, and ensure the site builds and uploads the Netlify functions.
2. Navigate back to the URL associated with the triggered deploy.
3. The site loads

![A Quokka happy to be eating](https://media.giphy.com/media/yxVRICzg06MyG73Kb6/giphy.gif)
